### PR TITLE
feat(nginx): add engine rest endpoint to nginx

### DIFF
--- a/platform-stack/nginx/nginx.conf
+++ b/platform-stack/nginx/nginx.conf
@@ -14,6 +14,18 @@ server {
             proxy_set_header    X-Forwarded-Proto  $scheme;
     }
 
+    location ^~ /engine-rest/ {
+                proxy_pass          http://host.docker.internal:8090/engine-rest/;
+                proxy_http_version  1.1;
+                proxy_set_header    Host               $host;
+                proxy_set_header    X-Real-IP          $remote_addr;
+                proxy_set_header    X-Forwarded-For    $proxy_add_x_forwarded_for;
+                proxy_set_header    X-Forwarded-Host   $host;
+                proxy_set_header    X-Forwarded-Server $host;
+                proxy_set_header    X-Forwarded-Port   $server_port;
+                proxy_set_header    X-Forwarded-Proto  $scheme;
+        }
+
     location ^~ /schema-registry/ {
                 proxy_pass          http://host.docker.internal:8091/;
                 proxy_http_version  1.1;


### PR DESCRIPTION
By adding the engine-rest endpoint to nginx we can deploy process artefacts directly to 8081 endpoint