### PR TITLE
fix(engine): downgrade miranum-deployment-receiver-rest-starter

### DIFF
--- a/miranum-engine/engine-backend/pom.xml
+++ b/miranum-engine/engine-backend/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.miragon.miranum</groupId>
             <artifactId>miranum-deployment-receiver-rest-starter</artifactId>
-            <version>0.3.0</version>
+            <version>0.2.1</version>
         </dependency>
 
         <!-- OpenApi -->


### PR DESCRIPTION
With updating the dependency  `miranum-deployment-receiver-rest-starter` in the `engine-backend` the EngineTasklistApplication was not able to start anymore. 
We are now reverting the dependency to version `0.2.1`. 

The newest version of  `miranum-deployment-receiver-rest-starter` is not working since it is using the Spring Boot v3 specific `springdoc-openapi-starter-webmvc-ui` as well as jakarta validation.

With this commit the engine should start up again. 